### PR TITLE
handle KeyboardInterrupt cleanly

### DIFF
--- a/train.py
+++ b/train.py
@@ -86,21 +86,24 @@ def main():
     x_train, y_train = transform(mnist_train)
     mnist_test = torchvision.datasets.MNIST("data", download=True, train=False)
     x_test, y_test = transform(mnist_test)
-    # Iterate over training epochs.
-    for i in range(1, EPOCHS+1):
-        # Train in batches.
-        train_loader = torch.utils.data.DataLoader(
-                dataset=list(zip(x_train, y_train)),
-                batch_size=512,
-                shuffle=True)
-        for x_batch, y_batch in train_loader:
-            train(model, x_batch, y_batch)
-        torch.save(model.state_dict(), "model.pt")
-        # Evaluate and checkpoint.
-        metrics = evaluate(model, x_test, y_test)
-        for metric, value in metrics.items():
-            dvclive.log(metric, value)
-        dvclive.next_step()
+    try:
+        # Iterate over training epochs.
+        for i in range(1, EPOCHS+1):
+            # Train in batches.
+            train_loader = torch.utils.data.DataLoader(
+                    dataset=list(zip(x_train, y_train)),
+                    batch_size=512,
+                    shuffle=True)
+            for x_batch, y_batch in train_loader:
+                train(model, x_batch, y_batch)
+            torch.save(model.state_dict(), "model.pt")
+            # Evaluate and checkpoint.
+            metrics = evaluate(model, x_test, y_test)
+            for metric, value in metrics.items():
+                dvclive.log(metric, value)
+            dvclive.next_step()
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Example should wrap the actual loop in `try`/`except` blocks to handle ctrl-c properly. Without the exception handling resuming via `dvc exp run` will not behave es expected (it will create "new" runs rather than properly extending the run which was killed via ctrl-c)

```
dvc exp show --no-pager                                                                             ⏎
┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┳━━━━━━━━┓
┃ Experiment            ┃ Created  ┃ step ┃    acc ┃
┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━╇━━━━━━━━┩
│ workspace             │ -        │   20 │ 0.9836 │
│ live                  │ 03:04 AM │    - │      - │
│ │ ╓ exp-60572         │ 05:10 PM │   20 │ 0.9836 │
│ │ ╟ 1234c39           │ 05:10 PM │   19 │ 0.9838 │
│ │ ╟ ebe6885           │ 05:10 PM │   18 │ 0.9831 │
│ │ ╟ 28cb5d0           │ 04:56 PM │   17 │ 0.9827 │
│ │ ╟ a171e56           │ 04:56 PM │   16 │ 0.9843 │
│ │ ╟ 6d5ea4d           │ 04:56 PM │   15 │ 0.9833 │
│ │ ╟ b5d2afc           │ 04:56 PM │   14 │ 0.9829 │
│ │ ╟ 3565bef           │ 04:55 PM │   13 │ 0.9828 │
│ │ ╟ 8f7d86a           │ 04:55 PM │   12 │ 0.9817 │
│ │ ╟ ff738b3           │ 04:55 PM │   11 │ 0.9776 │
│ │ ╟ d796a99           │ 04:55 PM │   10 │ 0.9765 │
│ │ ╟ 16928a6           │ 04:55 PM │    9 │ 0.9794 │
│ │ ╟ 780ff04 (47bddc3) │ 04:55 PM │    8 │ 0.9729 │
│ │ ╓ exp-b1d87         │ 04:54 PM │    7 │  0.976 │
│ │ ╟ fe7f0f2 (d6e50f1) │ 04:53 PM │    6 │ 0.9651 │
│ │ ╓ exp-bea83         │ 04:53 PM │    5 │ 0.9568 │
│ │ ╟ 2b530c6           │ 04:53 PM │    4 │ 0.9592 │
│ │ ╟ 713a9d5 (a87bc18) │ 04:53 PM │    3 │ 0.9436 │
│ │ ╓ exp-2e840         │ 04:52 PM │    2 │ 0.9198 │
│ │ ╟ 51f5d90           │ 04:52 PM │    1 │ 0.9093 │
│ ├─╨ c6bb3db           │ 04:52 PM │    0 │ 0.8577 │
└───────────────────────┴──────────┴──────┴────────┘
```

In this example, the separate experiments at the bottom happen because the ctrl-c is not handled properly, the continguous run at the top of the table was several ctrl-c + resumed runs after this change